### PR TITLE
Remove the --access public flag from the publish job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish
         run: |
           pnpm install
-          npm publish --provenance --access public
+          npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build Changelog


### PR DESCRIPTION
This flag is only needed the first time that the package is published with provenance.